### PR TITLE
DMC-729 Fix --header being sent twice on redirect

### DIFF
--- a/src/neon/neonrequest.cpp
+++ b/src/neon/neonrequest.cpp
@@ -242,6 +242,7 @@ void NEONRequest::configureRequest(){
     // reconfigure protos
     configureRequestParamsProto(*_current, params);
 
+    _headers_field.clear();
     std::copy(params.getHeaders().begin(), params.getHeaders().end(), std::back_inserter(_headers_field));
 
     // configure S3 params if needed


### PR DESCRIPTION
configureRequest() of neonrequest.cpp is called a second time if there is a redirect. This results in the extra header fields being added twice to the resulting request.

I'm not entirely sure if this is the correct way to fix it - could `_headers_field` contain anything useful at that point of execution?

Cheers, Georgios