### PR TITLE
Fix uuid.h in non-standard location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ add_definitions( -D__STDC_LIMIT_MACROS )     # C99 limit macros
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAG_ENABLE}")
 
-include_directories( ${HTTPLIB_PKG_INCLUDE_DIRS} ${GLIB2_PKG_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/deps ${CMAKE_CURRENT_SOURCE_DIR}/deps/libneon/src/ )
+include_directories( ${HTTPLIB_PKG_INCLUDE_DIRS} ${GLIB2_PKG_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/deps ${CMAKE_CURRENT_SOURCE_DIR}/deps/libneon/src/ ${UUID_INCLUDE_DIRS} )
 include_directories( ${CMAKE_SOURCE_DIR}/include/davix )
 include_directories( ${CMAKE_SOURCE_DIR}/src/libs/)
 


### PR DESCRIPTION
While CMakeLists.txt was searching for the uuid library and header it
did not add the header to the include path so it could not be used from
non-standard locations.