### PR TITLE
Use straight quotes in code example

### DIFF
--- a/doc/sphinx/lib-examples.rst
+++ b/doc/sphinx/lib-examples.rst
@@ -688,18 +688,18 @@ Davix::DavixException
 
 .. code-block:: cpp
 
-    throw DavixException(“Where”, “What”, “This is what has happened...”);
+    throw DavixException("Where", "What", "This is what has happened...");
 
 * Catch a ``DavixException``
 
 .. code-block:: cpp
 
     TRY_DAVIX{
-        DavFile myDavCollection(c, Uri(“davs://example.org/doomed_to_fail”));
+        DavFile myDavCollection(c, Uri("davs://example.org/doomed_to_fail"));
             myDavCollection.deletion(NULL);
     }CATCH_DAVIX(&err){
         std::cerr << err->getErrScope() <<
-        “ Error code: “ << err->getStatus() <<
+        " Error code: " << err->getStatus() <<
         " Error: " << err->getErrMsg() << std::endl;
 
         // handle error or propagate


### PR DESCRIPTION
.../davix-R_0_6_7/doc/sphinx/lib-examples.rst:689: WARNING: Could not lex literal_block as "cpp". Highlighting skipped.
.../davix-R_0_6_7/doc/sphinx/lib-examples.rst:695: WARNING: Could not lex literal_block as "cpp". Highlighting skipped.
